### PR TITLE
feat: Implement multi-color ants

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@
 
 I use this as part of my website CV which you can find at
 [eldolfin.github.io](https://eldolfin.github.io)
+
+## Parameter examples
+
+[Many small ants](https://eldolfin.github.io/langton.wasm/?alpha_retention=240&final_speed=0.5&number_of_ants=200&speedup_frames=0&start_x=0.5&start_y=0.5)
+[3 trailing ants](https://eldolfin.github.io/langton.wasm/?alpha_retention=255&final_speed=30&number_of_ants=3&speedup_frames=300&start_x=0.5&start_y=0.5)
+[angry ant](https://eldolfin.github.io/langton.wasm/?alpha_retention=220&final_speed=200&number_of_ants=1&speedup_frames=0)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ I use this as part of my website CV which you can find at
 [Many small ants](https://eldolfin.github.io/langton.wasm/?alpha_retention=240&final_speed=0.5&number_of_ants=200&speedup_frames=0&start_x=0.5&start_y=0.5)
 [3 trailing ants](https://eldolfin.github.io/langton.wasm/?alpha_retention=255&final_speed=30&number_of_ants=3&speedup_frames=300&start_x=0.5&start_y=0.5)
 [angry ant](https://eldolfin.github.io/langton.wasm/?alpha_retention=220&final_speed=200&number_of_ants=1&speedup_frames=0)
+[flies](https://eldolfin.github.io/langton.wasm/?alpha_retention=0&final_speed=1&number_of_ants=300&speedup_frames=300&start_x=0.5&start_y=0.5)
+[chaos](https://eldolfin.github.io/langton.wasm/?alpha_retention=255&debug=&final_speed=40&number_of_ants=300&speedup_frames=600&start_x=0.5&start_y=0.5)

--- a/lib/canvas/src/lib.rs
+++ b/lib/canvas/src/lib.rs
@@ -32,7 +32,7 @@ pub enum NamedColor {
     // TODO: the rest
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Color {
     Rgb { r: u8, g: u8, b: u8 },
     Rgba { r: u8, g: u8, b: u8, a: u8 },

--- a/lib/canvas/src/lib.rs
+++ b/lib/canvas/src/lib.rs
@@ -49,13 +49,17 @@ impl Color {
 
     fn invert(self) -> Self {
         match self {
-            Color::Rgb { r: _, g: _, b: _ } => unimplemented!(),
-            Color::Rgba {
-                r: _,
-                g: _,
-                b: _,
-                a: _,
-            } => unimplemented!(),
+            Color::Rgb { r, g, b } => Color::Rgb {
+                r: 255 - r,
+                g: 255 - g,
+                b: 255 - b,
+            },
+            Color::Rgba { r, g, b, a } => Color::Rgba {
+                r: 255 - r,
+                g: 255 - g,
+                b: 255 - b,
+                a, // Preserve alpha
+            },
             Color::Named(NamedColor::White) => Color::Named(NamedColor::Black),
             Color::Named(NamedColor::Black) => Color::Named(NamedColor::White),
         }
@@ -240,5 +244,18 @@ mod tests {
     #[case(Color::Rgba{r: 1, g: 2, b: 3, a: 4}, "#01020304")]
     pub fn test_color_to_css_string(#[case] color: Color, #[case] expected_str: &str) {
         assert_eq!(color.to_css_color(), expected_str);
+    }
+
+    #[rstest]
+    #[case(Color::Rgb { r: 0, g: 0, b: 0 }, Color::Rgb { r: 255, g: 255, b: 255 })]
+    #[case(Color::Rgb { r: 255, g: 255, b: 255 }, Color::Rgb { r: 0, g: 0, b: 0 })]
+    #[case(Color::Rgb { r: 10, g: 20, b: 30 }, Color::Rgb { r: 245, g: 235, b: 225 })]
+    #[case(Color::Rgba { r: 0, g: 0, b: 0, a: 100 }, Color::Rgba { r: 255, g: 255, b: 255, a: 100 })]
+    #[case(Color::Rgba { r: 255, g: 255, b: 255, a: 50 }, Color::Rgba { r: 0, g: 0, b: 0, a: 50 })]
+    #[case(Color::Rgba { r: 10, g: 20, b: 30, a: 0 }, Color::Rgba { r: 245, g: 235, b: 225, a: 0 })]
+    #[case(Color::Named(NamedColor::White), Color::Named(NamedColor::Black))]
+    #[case(Color::Named(NamedColor::Black), Color::Named(NamedColor::White))]
+    fn test_color_invert(#[case] original: Color, #[case] expected_inverted: Color) {
+        assert_eq!(original.invert(), expected_inverted);
     }
 }

--- a/src/langton/src/lib.rs
+++ b/src/langton/src/lib.rs
@@ -220,17 +220,17 @@ fn hue_to_rgb(hue: f32) -> Color {
     let x = c * (1.0 - (h_prime % 2.0 - 1.0).abs());
     let m = l - c / 2.0;
 
-    let (r_temp, g_temp, b_temp) = if h_prime >= 0.0 && h_prime < 1.0 {
+    let (r_temp, g_temp, b_temp) = if (0.0..1.0).contains(&h_prime) {
         (c, x, 0.0)
-    } else if h_prime >= 1.0 && h_prime < 2.0 {
+    } else if (1.0..2.0).contains(&h_prime) {
         (x, c, 0.0)
-    } else if h_prime >= 2.0 && h_prime < 3.0 {
+    } else if (2.0..3.0).contains(&h_prime) {
         (0.0, c, x)
-    } else if h_prime >= 3.0 && h_prime < 4.0 {
+    } else if (3.0..4.0).contains(&h_prime) {
         (0.0, x, c)
-    } else if h_prime >= 4.0 && h_prime < 5.0 {
+    } else if (4.0..5.0).contains(&h_prime) {
         (x, 0.0, c)
-    } else if h_prime >= 5.0 && h_prime <= 6.0 {
+    } else if (5.0..=6.0).contains(&h_prime) {
         (c, 0.0, x)
     } else {
         (0.0, 0.0, 0.0) // Should not happen with hue in 0-360

--- a/src/langton/src/lib.rs
+++ b/src/langton/src/lib.rs
@@ -102,7 +102,7 @@ impl Game {
         for i in 0..num_ants_val {
             let id = i;
             let hue = if num_ants_val > 0 {
-                (id as f64 * 360.0) / num_ants_val as f64
+                (id as f32 * 360.0) / num_ants_val as f32
             } else {
                 0.0
             };
@@ -150,12 +150,14 @@ impl Game {
                     let current_cell_state = self.board[ant.x][ant.y];
                     let new_cell_color;
                     match current_cell_state {
-                        None => { // Was white
+                        None => {
+                            // Was white
                             ant.direction = ant.direction.right();
                             self.board[ant.x][ant.y] = Some(ant.id);
                             new_cell_color = ant.color;
                         }
-                        Some(_) => { // Was black/colored by an ant
+                        Some(_) => {
+                            // Was black/colored by an ant
                             ant.direction = ant.direction.left();
                             self.board[ant.x][ant.y] = None;
                             new_cell_color = Color::Named(NamedColor::White);
@@ -209,11 +211,11 @@ impl Ant {
     }
 }
 
-fn hue_to_rgb(hue: f64) -> Color {
+fn hue_to_rgb(hue: f32) -> Color {
     let s = 1.0; // Saturation
     let l = 0.5; // Lightness
 
-    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let c = (1.0 - (2.0f32 * l - 1.0).abs()) * s;
     let h_prime = hue / 60.0;
     let x = c * (1.0 - (h_prime % 2.0 - 1.0).abs());
     let m = l - c / 2.0;


### PR DESCRIPTION
This commit introduces the capability for multiple ants to have distinct colors when displayed on the Langton's Ant simulation.

Key changes include:

- Modified the `Ant` struct to include an `id` and a `color` (of type `canvas::Color`).
- Implemented a `hue_to_rgb` function to generate unique colors for each ant by evenly distributing hues across the 0-360 degree spectrum and converting them to RGB. Saturation is fixed at 1.0 and lightness at 0.5 for vibrant colors.
- Refactored the board representation (`Game::board`) from storing a binary state (`BoardState`) to `Option<usize>`. `None` represents a "white" (or default) cell state, while `Some(ant_id)` represents a cell last flipped by the ant with that ID, taking on that ant's color.
- Updated the core game logic in `Game::run` to:
    - Determine ant turning behavior based on whether a cell is `None` or `Some(ant_id)`.
    - Set the cell state to `Some(ant.id)` (drawing `ant.color`) or `None` (drawing white) after an ant's move.
- Enhanced the `Color::invert` method in the canvas library to correctly invert `Color::Rgb` and `Color::Rgba` values. This allows the existing cell border rendering effect to function with the new custom ant colors. Alpha values are preserved during RGBA inversion.
- Added unit tests for the `Color::invert` method to verify its correctness for RGB, RGBA, and existing NamedColor types.

This feature allows for a more visually distinct representation of multiple ants operating simultaneously on the board.